### PR TITLE
Add pytest test for navbar links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ gopal-gautam.github.io
 2. Open the project folder in a web browser to view the website.
 3. Modify the HTML files and CSS as needed to customize the content and appearance.
 
+## Running Tests
+This project includes a small test suite powered by `pytest`. To run the tests, first install the dependencies and then execute `pytest` from the project root:
+
+```bash
+pip install -r requirements.txt  # if you haven't already
+pytest
+```
+
+The tests validate that the navigation bar links in `index.html` reference files that actually exist in the repository.
+
 ## Features
 - Responsive design for various screen sizes.
 - Navigation links for easy access to different sections.

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
 		<a href="index.html">Home</a>
 		<a href="gallery.html">Gallery</a>
 		<a href="blogs.html">Blogs</a>
-		<a href="about.html">About me</a>
+		<a href="aboutme.html">About me</a>
 	</div>
 
 	<div class="row">

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+beautifulsoup4

--- a/tests/test_navbar_links.py
+++ b/tests/test_navbar_links.py
@@ -1,0 +1,20 @@
+import os
+from bs4 import BeautifulSoup
+
+# Path to index.html relative to repo root
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
+
+
+def test_navbar_links_exist():
+    index_path = os.path.join(PROJECT_ROOT, 'index.html')
+    with open(index_path, 'r', encoding='utf-8') as f:
+        soup = BeautifulSoup(f, 'html.parser')
+
+    navbar = soup.find('div', class_='navbar')
+    assert navbar is not None, "Navbar not found"
+
+    links = [a['href'] for a in navbar.find_all('a', href=True)]
+
+    for link in links:
+        assert os.path.isfile(os.path.join(PROJECT_ROOT, link)), f"Missing file for link: {link}"
+


### PR DESCRIPTION
## Summary
- add pytest-based test to verify navbar links
- fix link in `index.html` navbar
- document how to run tests
- add Python test dependencies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842d7335080832e98925047bded66da