### PR TITLE
Fix missing closing head tag in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
 	<title>Gopal Gautam</title>
 	<link href="https://fonts.googleapis.com/css?family=Lobster|Lobster+Two" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Dosis|Yatra+One" rel="stylesheet">
-	<link href="css/style.css" rel="stylesheet" type="text/css" />
+        <link href="css/style.css" rel="stylesheet" type="text/css" />
+</head>
 <body>
 
 


### PR DESCRIPTION
## Summary
- properly close the `<head>` section on the homepage

## Testing
- `tidy -errors -q index.html`

------
https://chatgpt.com/codex/tasks/task_e_6842d715c914832ebe60aabffa4f5724